### PR TITLE
fix Array.concat doesn't exist in Array. use Array.prototype or []

### DIFF
--- a/js/autocompleteSelect.js
+++ b/js/autocompleteSelect.js
@@ -112,7 +112,7 @@ $(function() {
                     } else {
                         elVal.val(ui.item.value);
                     }
-                    el.val(Array.concat($.map(elVal.val().split(','), function(arg) {
+                    el.val([].concat($.map(elVal.val().split(','), function(arg) {
                         return labelCache[arg];
                     }), ['']).join(', '));
                     return false;


### PR DESCRIPTION
http://stackoverflow.com/questions/37467167/array-concat-apply-different-in-chrome-and-firefox